### PR TITLE
use scala 3 libs in scala 3 build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,19 +17,19 @@ credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
 libraryDependencies ++= {
   val simpleclientVersion = "0.16.0"
   val pekkoVersion = "1.0.2"
-  val pekkoHttpVersion = "1.0.0"
+  val pekkoHttpVersion = "1.0.1"
   val scalaTestVersion = "3.2.17"
 
   Seq(
-    ("org.apache.pekko" %% "pekko-actor"           % pekkoVersion     % Provided).cross(CrossVersion.for3Use2_13),
-    ("org.apache.pekko" %% "pekko-stream"          % pekkoVersion     % Provided).cross(CrossVersion.for3Use2_13),
-    ("org.apache.pekko" %% "pekko-http"            % pekkoHttpVersion % Provided).cross(CrossVersion.for3Use2_13),
-    ("org.apache.pekko" %% "pekko-http-spray-json" % pekkoHttpVersion % Provided).cross(CrossVersion.for3Use2_13),
-    "io.prometheus"      % "simpleclient"          % simpleclientVersion,
-    "io.prometheus"      % "simpleclient_common"   % simpleclientVersion,
-    ("org.apache.pekko" %% "pekko-testkit"         % pekkoVersion     % Test).cross(CrossVersion.for3Use2_13),
-    ("org.apache.pekko" %% "pekko-http-testkit"    % pekkoHttpVersion % Test).cross(CrossVersion.for3Use2_13),
-    "org.scalatest"     %% "scalatest"             % scalaTestVersion % Test
+    "org.apache.pekko" %% "pekko-actor"           % pekkoVersion     % Provided,
+    "org.apache.pekko" %% "pekko-stream"          % pekkoVersion     % Provided,
+    "org.apache.pekko" %% "pekko-http"            % pekkoHttpVersion % Provided,
+    "org.apache.pekko" %% "pekko-http-spray-json" % pekkoHttpVersion % Provided,
+    "io.prometheus"      % "simpleclient"         % simpleclientVersion,
+    "io.prometheus"      % "simpleclient_common"  % simpleclientVersion,
+    "org.apache.pekko" %% "pekko-testkit"         % pekkoVersion     % Test,
+    "org.apache.pekko" %% "pekko-http-testkit"    % pekkoHttpVersion % Test,
+    "org.scalatest"     %% "scalatest"            % scalaTestVersion % Test
   )
 }
 


### PR DESCRIPTION
Pekko supports Scala 3.

It is not recommended for libs to depend on the cross for behaviour.
https://www.scala-lang.org/blog/2021/04/08/scala-3-in-sbt.html -- see the disclaimer


> DISCLAIMER FOR LIBRARY MAINTAINERS
> Using the interoperability between Scala 2.13 and Scala 3 in a published library is generally not safe for your end-users. Unless you know exactly what you are doing, it is discouraged to publish a Scala 3 library that depends on a Scala 2.13 library (the scala-library being excluded) or vice versa. The reason is to prevent library users from ending up with two conflicting versions foo_2.13 and foo_3 of the same foo library in their classpath, this problem being unsolvable in some cases.
